### PR TITLE
Fixes missing value in the labels "for" attribute

### DIFF
--- a/components/customform/form.htm
+++ b/components/customform/form.htm
@@ -9,7 +9,7 @@
     <div class="{{ form.rowClass() }}">
         {% for field in form.fields %}
         <div class="custom-form-input abweb-form-{{ field.type }} {{ form.groupClass(field) }}">
-            <label for="{{ form.id(field) }}" class="{{ form.labelClass(field) }}">
+            <label for="{{ field.getId(form) }}" class="{{ form.labelClass(field) }}">
                 {{ field.name }}
                 {% if field.required %}<span class="required"></span>{% endif %}
             </label>


### PR DESCRIPTION
form.id(field) doesn't return anything and the for attribute for labels stays empty.